### PR TITLE
Add '.pbf' Extension

### DIFF
--- a/PureBasic.sublime-syntax
+++ b/PureBasic.sublime-syntax
@@ -3,6 +3,7 @@
 file_extensions:
   - pb
   - pbi
+  - pbf
 scope: source.purebasic
 variables:
   following_pointer: '(\s*(\*))?'


### PR DESCRIPTION
Add to syntax missing `.pbf` extension for PB forms.