### PR TITLE
Polish Syntax

### DIFF
--- a/PureBasic.sublime-syntax
+++ b/PureBasic.sublime-syntax
@@ -204,9 +204,9 @@ contexts:
     #
     - match: '(\*)?(\w+)(\$)?'
       captures:
-        1: variable.other.member.purebasic punctuation.definition.variable.purebasic
-        2: variable.other.member.purebasic
-        3: variable.other.member.purebasic punctuation.definition.variable.purebasic
+        0: variable.other.member.purebasic
+        1: punctuation.definition.variable.purebasic
+        3: punctuation.definition.variable.purebasic
 
   labels:
     - match: '\b((\w+)(:))\s*$'
@@ -289,9 +289,9 @@ contexts:
     #
     - match: '{{variables}}'
       captures:
-        1: variable.parameter.purebasic punctuation.definition.variable.purebasic
-        2: variable.parameter.purebasic
-        3: variable.parameter.purebasic punctuation.definition.variable.purebasic
+        0: variable.parameter.purebasic
+        1: punctuation.definition.variable.purebasic
+        3: punctuation.definition.variable.purebasic
     - include: constants
 
   #
@@ -405,12 +405,12 @@ contexts:
   variables:
     - match: '{{variables}}'
       captures:
-        1: variable.other.purebasic punctuation.definition.variable.purebasic
-        2: variable.other.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
+        0: variable.other.purebasic
+        1: punctuation.definition.variable.purebasic
+        3: punctuation.definition.variable.purebasic
 
   constants:
     - match: '(#)([\w_]+)\b'
       captures:
-        1: variable.other.constant.purebasic punctuation.definition.variable.purebasic
-        2: variable.other.constant.purebasic
+        0: variable.other.constant.purebasic
+        1: punctuation.definition.variable.purebasic


### PR DESCRIPTION
Optimize capture groups by using group 0 to avoid redundant scopes.