### PR TITLE
Migrate to ST4 (closes #40)

### DIFF
--- a/PureBasic.sublime-syntax
+++ b/PureBasic.sublime-syntax
@@ -5,6 +5,7 @@ file_extensions:
   - pbi
   - pbf
 scope: source.purebasic
+version: 2
 variables:
   following_pointer: '(\s*(\*))?'
   opening_parens: '(\()(\*)?'


### PR DESCRIPTION
Add to syntax `version: 2` to enable ST4 syntax engine.