### PR TITLE
Operators Fixes (#44)

### DIFF
--- a/PureBasic.sublime-syntax
+++ b/PureBasic.sublime-syntax
@@ -243,30 +243,13 @@ contexts:
       scope: constant.numeric.purebasic
 
   keywords:
-    - match: '(\+|-|\*|/|%|<<|>>){{following_pointer}}'
-      captures:
-        1: keyword.operator.arithmetic.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
-
-    - match: '&|\||!|~'
-      scope: keyword.operator.bitwise.purebasic
-
-    - match: '<|>|<>|<=|>='
-      scope: keyword.comparison.purebasic
-
-    - match: '(=){{following_pointer}}'
-      captures:
-        1: keyword.operator.assignment.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
+    - include: operators_all
 
     - match: '\b(?i:Break|Case|Continue|CompilerCase|CompilerDefault|CompilerElse|CompilerElseIf|CompilerEndIf|CompilerEndSelect|CompilerIf|CompilerSelect|Default|Else|End|EndIf|EndSelect|ElseIf|Else|FakeReturn|For|ForEach|Forever|Gosub|Goto|If|Next|Repeat|Select|To|Until|Wend|While)\b'
       scope: keyword.control.purebasic
 
     - match: '\b(?i:DataSection|EndDataSection|IncludeFile|IncludePath|XIncludeFile)\b'
       scope: keyword.control.import.purebasic
-
-    - match: '\b(?i:And|Not|Or|XOr)\b'
-      scope: keyword.logical.purebasic
 
     - match: '\b(?i:Interface)\b'
       scope: keyword.declaration.purebasic
@@ -415,3 +398,35 @@ contexts:
       captures:
         0: variable.other.constant.purebasic
         1: punctuation.definition.variable.purebasic
+
+  operators_all:
+    - include: operators_arithmetic
+    - include: operators_assignment
+    - include: operators_comparison
+    - include: operators_logical
+    - include: operators_bitwise
+  operators_arithmetic:
+    - match: '(\+|-|\*|/|%|<<|>>){{following_pointer}}'
+      captures:
+        1: keyword.operator.arithmetic.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+  operators_assignment:
+    - match: '(=(?![<>])){{following_pointer}}'
+      captures:
+        1: keyword.operator.assignment.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+  operators_comparison:
+    - match: '(<=?|>=?|=<?|=>?|<>){{following_pointer}}'
+      captures:
+        1: keyword.operator.comparison.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+  operators_logical:
+    - match: '(?i)\b(And|Or|XOr|Not)\b{{following_pointer}}'
+      captures:
+        1: keyword.operator.word.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+  operators_bitwise:
+    - match: '(&|\||!|~){{following_pointer}}'
+      captures:
+        1: keyword.operator.bitwise.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic

--- a/PureBasic.sublime-syntax
+++ b/PureBasic.sublime-syntax
@@ -37,6 +37,12 @@ contexts:
         - match: '$'
           pop: true
 
+  constants:
+    - match: '(#)([\w_]+)\b'
+      captures:
+        0: variable.other.constant.purebasic
+        1: punctuation.definition.variable.purebasic
+
   declarations:
     - match: '\b(?i:(Enumeration|EnumerationBinary))(\s+(\D\w+))?\b'
       captures:
@@ -259,6 +265,43 @@ contexts:
         1: keyword.other.purebasic
         3: variable.other.purebasic punctuation.definition.variable.purebasic
 
+  operators_all:
+    - include: operators_arithmetic
+    - include: operators_assignment
+    - include: operators_comparison
+    - include: operators_logical
+    - include: operators_bitwise
+
+  operators_arithmetic:
+    - match: '(\+|-|\*|/|%|<<|>>){{following_pointer}}'
+      captures:
+        1: keyword.operator.arithmetic.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+
+  operators_assignment:
+    - match: '(=(?![<>])){{following_pointer}}'
+      captures:
+        1: keyword.operator.assignment.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+
+  operators_bitwise:
+    - match: '(&|\||!|~){{following_pointer}}'
+      captures:
+        1: keyword.operator.bitwise.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+
+  operators_comparison:
+    - match: '(<=?|>=?|=<?|=>?|<>){{following_pointer}}'
+      captures:
+        1: keyword.operator.comparison.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+
+  operators_logical:
+    - match: '(?i)\b(And|Or|XOr|Not)\b{{following_pointer}}'
+      captures:
+        1: keyword.operator.word.purebasic
+        3: variable.other.purebasic punctuation.definition.variable.purebasic
+
   #
   # Whatever can occur inside the parenthesis of a procedure declaration.
   #
@@ -392,41 +435,3 @@ contexts:
         0: variable.other.purebasic
         1: punctuation.definition.variable.purebasic
         3: punctuation.definition.variable.purebasic
-
-  constants:
-    - match: '(#)([\w_]+)\b'
-      captures:
-        0: variable.other.constant.purebasic
-        1: punctuation.definition.variable.purebasic
-
-  operators_all:
-    - include: operators_arithmetic
-    - include: operators_assignment
-    - include: operators_comparison
-    - include: operators_logical
-    - include: operators_bitwise
-  operators_arithmetic:
-    - match: '(\+|-|\*|/|%|<<|>>){{following_pointer}}'
-      captures:
-        1: keyword.operator.arithmetic.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
-  operators_assignment:
-    - match: '(=(?![<>])){{following_pointer}}'
-      captures:
-        1: keyword.operator.assignment.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
-  operators_comparison:
-    - match: '(<=?|>=?|=<?|=>?|<>){{following_pointer}}'
-      captures:
-        1: keyword.operator.comparison.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
-  operators_logical:
-    - match: '(?i)\b(And|Or|XOr|Not)\b{{following_pointer}}'
-      captures:
-        1: keyword.operator.word.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic
-  operators_bitwise:
-    - match: '(&|\||!|~){{following_pointer}}'
-      captures:
-        1: keyword.operator.bitwise.purebasic
-        3: variable.other.purebasic punctuation.definition.variable.purebasic

--- a/Tests/syntax_test_arithmetic_operators.pb
+++ b/Tests/syntax_test_arithmetic_operators.pb
@@ -1,33 +1,51 @@
-﻿; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+﻿;; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+
+; For info, see "Variables and Types":
+; https://www.purebasic.com/documentation/reference/variables.html
 
 EnableExplicit
 
 Global Result
 
 Result = 1 + 2
-;      ^ keyword.operator.assignment.purebasic
-;          ^ keyword.operator.arithmetic.purebasic
+;;     ^        keyword.operator.assignment
+;;         ^    keyword.operator.arithmetic
 
 Result = 1 - 2
-;      ^ keyword.operator.assignment.purebasic
-;          ^ keyword.operator.arithmetic.purebasic
+;;     ^        keyword.operator.assignment
+;;         ^    keyword.operator.arithmetic
 
 Result = 1 * 2
-;      ^ keyword.operator.assignment.purebasic
-;          ^ keyword.operator.arithmetic.purebasic
+;;     ^        keyword.operator.assignment
+;;         ^    keyword.operator.arithmetic
 
 Result = 1 / 2
-;      ^ keyword.operator.assignment.purebasic
-;          ^ keyword.operator.arithmetic.purebasic
+;;     ^        keyword.operator.assignment
+;;         ^    keyword.operator.arithmetic
 
 Result = 1 % 2
-;      ^ keyword.operator.assignment.purebasic
-;          ^ keyword.operator.arithmetic.purebasic
+;;     ^        keyword.operator.assignment
+;;         ^    keyword.operator.arithmetic
 
 Result = %1011 << 1
-;      ^ keyword.operator.assignment.purebasic
-;              ^^ keyword.operator.arithmetic.purebasic
+;;     ^              keyword.operator.assignment
+;;             ^^     keyword.operator.arithmetic
 
 Result = 16 >> 1
-;      ^ keyword.operator.assignment.purebasic
-;           ^^ keyword.operator.arithmetic.purebasic
+;;     ^           keyword.operator.assignment
+;;          ^^     keyword.operator.arithmetic
+
+; Test Pointers
+; =============
+; Because 'operators_arithmetic' also handles pointer variables.
+
+Define a = 10
+Define *ap = a
+#BC = 5
+
+Result = #BC + *ap
+;;             ^^^   variable.other
+;;             ^     punctuation.definition.variable
+;;           ^       keyword.operator.arithmetic
+;;       ^^^         variable.other.constant
+;;       ^           punctuation.definition.variable

--- a/Tests/syntax_test_bitwise_operators.pb
+++ b/Tests/syntax_test_bitwise_operators.pb
@@ -1,17 +1,36 @@
-﻿; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+﻿;; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+
+; For info, see "Variables and Types":
+; https://www.purebasic.com/documentation/reference/variables.html
 
 EnableExplicit
 
 Global BitwiseResult.w
 
 BitwiseResult = %1000 & %0101
-;                     ^ keyword.operator.bitwise.purebasic
+;;                    ^ keyword.operator.bitwise
 
 BitwiseResult = %1000 | %0101
-;                     ^ keyword.operator.bitwise.purebasic
+;;                    ^ keyword.operator.bitwise
 
 BitwiseResult = %1000 ! %0101
-;                     ^ keyword.operator.bitwise.purebasic
+;;                    ^ keyword.operator.bitwise
 
 BitwiseResult = ~%1000
-;               ^ keyword.operator.bitwise.purebasic
+;;              ^ keyword.operator.bitwise
+
+
+; Test Pointers
+; =============
+; Because 'operators_bitwise' also handles pointer variables.
+
+Define a = %1001
+Define *ap = a
+#BC = %0001
+
+BitwiseResult = #BC & *ap
+;;                    ^^^   variable.other
+;;                    ^     punctuation.definition.variable
+;;              ^^^         variable.other.constant
+;;              ^           punctuation.definition.variable
+;;                  ^       keyword.operator.bitwise

--- a/Tests/syntax_test_comparison_operators.pb
+++ b/Tests/syntax_test_comparison_operators.pb
@@ -1,4 +1,4 @@
-﻿;; SYNTAX TEST "Packages/Purebasic/Purebasic.sublime-syntax"
+﻿;; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
 
 ; For info, see "Variables and Types":
 ; https://www.com/documentation/reference/variables.html

--- a/Tests/syntax_test_comparison_operators.pb
+++ b/Tests/syntax_test_comparison_operators.pb
@@ -1,0 +1,41 @@
+﻿;; SYNTAX TEST "Packages/Purebasic/Purebasic.sublime-syntax"
+
+; For info, see "Variables and Types":
+; https://www.com/documentation/reference/variables.html
+
+a = 31
+b = 32
+
+If a = 31 : Debug "Equal" : EndIf
+
+; NOTE: The '=' is currently being scoped as 'assignment' since we haven't yet
+;       figured out how to capture it according to context. (Issue #44)
+
+If a <> b : Debug "Unequal" : EndIf
+;;   ^^ keyword.operator.comparison
+If b > a : Debug "Greater" : EndIf
+;;   ^ keyword.operator.comparison
+If a < b : Debug "Less" : EndIf
+;;   ^ keyword.operator.comparison
+If b >= a : Debug "Greater or equal" : EndIf
+;;   ^^ keyword.operator.comparison
+If b => a : Debug "Greater or equal" : EndIf
+;;   ^^ keyword.operator.comparison
+If a <= b : Debug "Less or equal" : EndIf
+;;   ^^ keyword.operator.comparison
+If a =< b : Debug "Less or equal" : EndIf
+;;   ^^ keyword.operator.comparison
+
+; Test Pointers
+; =============
+; Because 'operators_comparison' also handles pointer variables.
+
+*ap = a
+#BC = 32
+
+If #BC >= *ap : Debug "Equal" : EndIf
+;;        ^^^   variable.other
+;;        ^     punctuation.definition.variable
+;;     ^^       keyword.operator.comparison
+;; ^^^          variable.other.constant
+;; ^            punctuation.definition.variable

--- a/Tests/syntax_test_logical_operators.pb
+++ b/Tests/syntax_test_logical_operators.pb
@@ -45,8 +45,8 @@ Define *Leftp = Left
 #RightC = #False
 
 If #RightC And *Left : Debug #True : EndIf
-;;             ^^^   variable.other
-;;             ^     punctuation.definition.variable
-;;         ^^^       keyword.operator.word
-;; ^^^^^^^           variable.other.constant
 ;; ^                 punctuation.definition.variable
+;; ^^^^^^^           variable.other.constant
+;;         ^^^       keyword.operator.word
+;;             ^     punctuation.definition.variable
+;;             ^^^^^ variable.other

--- a/Tests/syntax_test_logical_operators.pb
+++ b/Tests/syntax_test_logical_operators.pb
@@ -1,26 +1,52 @@
-﻿; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+﻿;; SYNTAX TEST "Packages/PureBasic/PureBasic.sublime-syntax"
+
+; For info, see "Variables and Types":
+; https://www.com/documentation/reference/variables.html
 
 EnableExplicit
 
 Global Left = #True
 Global Right = #False
 
-If Left And Right
-;       ^^^ keyword.logical.purebasic
-    Debug #True
-EndIf
+If Left And Right : Debug #True : EndIf
+;;      ^^^   keyword.operator.word
 
-If Left Or Right
-;       ^^ keyword.logical.purebasic
-    Debug #True
-EndIf
+If Left Or Right : Debug #True : EndIf
+;;      ^^   keyword.operator.word
 
-If Not Left And Right
-;  ^^^ keyword.logical.purebasic
-    Debug #True
-EndIf
+If Not Left And Right : Debug #True : EndIf
+;; ^^^            keyword.operator.word
+;;          ^^^   keyword.operator.word
 
-If Left XOr Right
-;       ^^^ keyword.logical.purebasic
-    Debug #True
-EndIf
+If Left XOr Right : Debug #True : EndIf
+;;      ^^^   keyword.operator.word
+
+; Test for case-sensitivity
+; =========================
+
+If Left and Right : Debug #True : EndIf
+;;      ^^^   keyword.operator.word
+
+If Left or Right : Debug #True : EndIf
+;;      ^^   keyword.operator.word
+
+If not Left and Right : Debug #True : EndIf
+;; ^^^            keyword.operator.word
+;;          ^^^   keyword.operator.word
+
+If Left xor Right : Debug #True : EndIf
+;;      ^^^   keyword.operator.word
+
+; Test Pointers
+; =============
+; Because 'operators_logical' also handles pointer variables.
+
+Define *Leftp = Left
+#RightC = #False
+
+If #RightC And *Left : Debug #True : EndIf
+;;             ^^^   variable.other
+;;             ^     punctuation.definition.variable
+;;         ^^^       keyword.operator.word
+;; ^^^^^^^           variable.other.constant
+;; ^                 punctuation.definition.variable


### PR DESCRIPTION
Move all operators definitions to independently named contexts, so that
they might included according to context in the future.

Fix comparison operators RegEx to ensure that bi-character operators
are captured as a single token, so that ligatures are shown correctly.

Amend capturing scope of logical operators from `keyword.logical` to
`keyword.operator.word`.

Ensure that all operators RegExs include `{{following_pointer}}` in their
definition, and add coverage tests for pointers following operators.

Update all operators tests accordingly.